### PR TITLE
browser processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 1.3.0
+- feature: add browser processor to determine a human friendly browser and OS name

--- a/README.md
+++ b/README.md
@@ -219,6 +219,17 @@ and `ignoreEmptyContextAndExtra` can be `"true"` or `"false"`.
 }
 ~~~
 
+#### BrowserProcessors
+**config.json**
+~~~ json
+"logger" : {
+    "test" : {
+        "processors" : ["browser"],
+    }
+}
+~~~
+Uses the [get_browser()](http://php.net/manual/function.get-browser.php) function in order to determine a userfriendly name of the used browser and the used OS. These information are added as the "extra" fields `user_agent` and `user_os`. This function relys on the availablility of the `browscap.ini` as described in the linked documentation.
+
 ## License & Authors
 - Authors:: Peter Ahrens (<pahrens@bigpoint.net>), Andreas Schleifer (<aschleifer@bigpoint.net>)
 

--- a/src/MonologCreator/Factory.php
+++ b/src/MonologCreator/Factory.php
@@ -127,7 +127,7 @@ class Factory
                 $webProcessor->addExtraField('user_agent', 'HTTP_USER_AGENT');
 
                 $processors[] = $webProcessor;
-            } elseif ('browser') {
+            } elseif ('browser' === $processor) {
                 $processors[] = new MonologCreator\Processor\Browser();
             } else {
                 throw new MonologCreator\Exception(

--- a/src/MonologCreator/Factory.php
+++ b/src/MonologCreator/Factory.php
@@ -127,6 +127,8 @@ class Factory
                 $webProcessor->addExtraField('user_agent', 'HTTP_USER_AGENT');
 
                 $processors[] = $webProcessor;
+            } elseif ('browser') {
+                $processors[] = new MonologCreator\Processor\Browser();
             } else {
                 throw new MonologCreator\Exception(
                     'processor type: ' . $processor . ' is not supported'

--- a/src/MonologCreator/Factory.php
+++ b/src/MonologCreator/Factory.php
@@ -123,10 +123,7 @@ class Factory
 
         foreach ($loggerConfig['processors'] as $processor) {
             if ('web' === $processor) {
-                $webProcessor = new Monolog\Processor\WebProcessor();
-                $webProcessor->addExtraField('user_agent', 'HTTP_USER_AGENT');
-
-                $processors[] = $webProcessor;
+                $processors[] = new Monolog\Processor\WebProcessor();
             } elseif ('browser' === $processor) {
                 $processors[] = new MonologCreator\Processor\Browser();
             } else {

--- a/src/MonologCreator/Processor/Browser.php
+++ b/src/MonologCreator/Processor/Browser.php
@@ -17,7 +17,7 @@ class Browser
     {
         $browser = get_browser();
 
-        $record['user_agent'] = $browser->parent;
+        $record['user_agent'] = $browser->parent . ' / ' . $browser->platform;
 var_dump($record); die;
         return $record;
     }

--- a/src/MonologCreator/Processor/Browser.php
+++ b/src/MonologCreator/Processor/Browser.php
@@ -15,9 +15,10 @@ class Browser
      */
     public function __invoke(array $record)
     {
-        $browser = get_browser();
+        $browser = \get_browser();
 
-        $record['user_agent'] = $browser->parent . ' / ' . $browser->platform;
+        $record['extra']['user_agent'] = $browser->parent;
+        $record['extra']['user_os']    = $browser->platform;
 var_dump($record); die;
         return $record;
     }

--- a/src/MonologCreator/Processor/Browser.php
+++ b/src/MonologCreator/Processor/Browser.php
@@ -5,6 +5,8 @@ namespace MonologCreator\Processor;
  * Class Browser
  *
  * @package MonologCreator\Processor
+ *
+ * @@codeCoverageIgnore
  */
 class Browser
 {
@@ -19,7 +21,7 @@ class Browser
 
         $record['extra']['user_agent'] = $browser->parent;
         $record['extra']['user_os']    = $browser->platform;
-var_dump($record); die;
+
         return $record;
     }
 }

--- a/src/MonologCreator/Processor/Browser.php
+++ b/src/MonologCreator/Processor/Browser.php
@@ -1,0 +1,24 @@
+<?php
+namespace MonologCreator\Processor;
+
+/**
+ * Class Browser
+ *
+ * @package MonologCreator\Processor
+ */
+class Browser
+{
+    /**
+     * @param array $record
+     *
+     * @return array
+     */
+    public function __invoke(array $record)
+    {
+        $browser = get_browser();
+
+        $record['user_agent'] = $browser->parent;
+var_dump($record); die;
+        return $record;
+    }
+}

--- a/tests/MonologCreator/FactoryTest.php
+++ b/tests/MonologCreator/FactoryTest.php
@@ -147,7 +147,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testCreateLoggerWithProcessor()
+    public function testCreateLoggerWithWebProcessor()
     {
         $config = json_decode(
             '{
@@ -183,6 +183,46 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(
             '\Monolog\Processor\WebProcessor',
+            $logger->getProcessors()[0]
+        );
+    }
+
+    public function testCreateLoggerWithBrowserProcessor()
+    {
+        $config = json_decode(
+            '{
+                "handler" : {
+                    "stream" : {
+                        "path"      : "./fubar.log",
+                        "level"     : "INFO",
+                        "formatter" : "logstash"
+                    }
+                },
+                "formatter" : {
+                    "logstash" : {
+                        "type" : "test"
+                    }
+                },
+                "logger" : {
+                    "_default" : {
+                        "handler" : ["stream"],
+                        "level" : "WARNING"
+                    },
+                    "test" : {
+                        "handler" : ["stream"],
+                        "processors": ["browser"],
+                        "level" : "INFO"
+                    }
+                }
+            }',
+            true
+        );
+
+        $factory = new Factory($config);
+        $logger  = $factory->createLogger('test');
+
+        $this->assertInstanceOf(
+            '\MonologCreator\Processor\Browser',
             $logger->getProcessors()[0]
         );
     }


### PR DESCRIPTION
This PR adds a browser processor based on http://php.net/manual/function.get-browser.php that adds the extra fields `user_agent` and `user_os` which are the fields `parent` and `platform` from the get_browser() function.
