### PR TITLE
[feature] Request-ID Processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ composer require bigpoint/monolog-creator
 
 #### minimal
 
-You have to configurate at least the `_default` logger and one handler.
+You have to configure at least the `_default` logger and one handler.
 
 **config.json**
 ~~~ json
@@ -219,11 +219,23 @@ and `ignoreEmptyContextAndExtra` can be `"true"` or `"false"`.
 }
 ~~~
 
+#### RequestID Processor
+Injects a random UUID for each request to make multiple log messages from the same request easier to follow. 
+
+**config.json**
+~~~ json
+"logger" : {
+    "test" : {
+        "processors" : ["requestId"],
+    }
+}
+~~~
+
 ## License & Authors
-- Authors:: Peter Ahrens (<pahrens@bigpoint.net>), Andreas Schleifer (<aschleifer@bigpoint.net>)
+- Authors:: Peter Ahrens (<pahrens@bigpoint.net>), Andreas Schleifer (<aschleifer@bigpoint.net>), Hendrik Meyer (hmeyer@bigpoint.net)
 
 ```text
-Copyright:: 2015 Bigpoint GmbH
+Copyright:: 2015-2016 Bigpoint GmbH
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,10 @@
         {
             "name": "Andreas Schleifer",
             "email": "aschleifer@bigpoint.net"
+        },
+        {
+            "name": "Hendrik Meyer",
+            "email": "hmeyer@bigpoint.net"
         }
     ],
     "support" : {

--- a/src/MonologCreator/Factory.php
+++ b/src/MonologCreator/Factory.php
@@ -127,6 +127,8 @@ class Factory
                 $webProcessor->addExtraField('user_agent', 'HTTP_USER_AGENT');
 
                 $processors[] = $webProcessor;
+            } elseif ('requestId' === $processor) {
+                $processors[] = new Processor\RequestId();
             } else {
                 throw new MonologCreator\Exception(
                     'processor type: ' . $processor . ' is not supported'

--- a/src/MonologCreator/Processor/RequestId.php
+++ b/src/MonologCreator/Processor/RequestId.php
@@ -10,15 +10,7 @@ class RequestId
     /**
      * @var string
      */
-    private $_uuid;
-
-    /**
-     * RequestId constructor.
-     */
-    public function __construct()
-    {
-        $this->_uuid = $this->_generateUUID();
-    }
+    private $_uuid = '';
 
     /**
      * Called by Monolog - Allows processors to manipulate data.
@@ -30,6 +22,9 @@ class RequestId
      */
     public function __invoke(array $record)
     {
+        if (true === empty($this->_uuid)) {
+            $this->_uuid = $this->_generateUUID();
+        }
         $record['extra']['request_id'] = $this->_uuid;
 
         return $record;

--- a/src/MonologCreator/Processor/RequestId.php
+++ b/src/MonologCreator/Processor/RequestId.php
@@ -10,32 +10,34 @@ class RequestId
     /**
      * @var string
      */
-    protected $uuid;
+    private $_uuid;
 
-    public function __construct($uuid = null)
+    /**
+     * RequestId constructor.
+     */
+    public function __construct()
     {
-        if (null === $uuid) {
-            $this->uuid = $this->_generateUUID();
-        } else {
-            $this->uuid = $uuid;
-        }
+        $this->_uuid = $this->_generateUUID();
     }
 
     /**
-     * @param  array $record
+     * Called by Monolog - Allows processors to manipulate data.
      *
-     * @return array
+     *
+     * @param  array $record    The record to log
+     *
+     * @return array            The updated record to log
      */
     public function __invoke(array $record)
     {
-        $record['extra'] = array(
-            'request_id' => $this->uuid,
-        );
+        $record['extra']['request_id'] = $this->_uuid;
 
         return $record;
     }
 
     /**
+     * Generate a valid UUIDv4 utilizing the system´s available (P)RNGs.
+     *
      * @return string valid UUIDv4
      */
     protected function _generateUUID()
@@ -130,6 +132,8 @@ class RequestId
     }
 
     /**
+     * Generate a valid UUIDv4 from provided random data.
+     *
      * A UUIDv4 is formatted
      * xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
      * where x is 0-9, A-F and y is 8-9, A-B.
@@ -138,7 +142,7 @@ class RequestId
      *
      * @return string           valid, formatted UUIDv4
      */
-    protected function _generateUUIDFromData($data)
+    private function _generateUUIDFromData($data)
     {
         $data = substr($data, 0, 16);
 

--- a/src/MonologCreator/Processor/RequestId.php
+++ b/src/MonologCreator/Processor/RequestId.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace MonologCreator\Processor;
+
+/**
+ * Injects a per-request UUID into the log output.
+ */
+class RequestId
+{
+    /**
+     * @var string
+     */
+    protected $uuid;
+
+    public function __construct($uuid = null)
+    {
+        if (null === $uuid) {
+            $this->uuid = $this->_generateUUID();
+        } else {
+            $this->uuid = $uuid;
+        }
+    }
+
+    /**
+     * @param  array $record
+     *
+     * @return array
+     */
+    public function __invoke(array $record)
+    {
+        $record['extra'] = array(
+            'request_id' => $this->uuid,
+        );
+
+        return $record;
+    }
+
+    /**
+     * @return string valid UUIDv4
+     */
+    protected function _generateUUID()
+    {
+        $data = null;
+        switch (true) {
+            case $this->_isCallable('random_bytes'):
+                $data = $this->_randomBytes(16);
+                break;
+            case $this->_isCallable('openssl_random_pseudo_bytes'):
+                $data = $this->_opensslRandomPseudoBytes(16);
+                break;
+            case $this->_isCallable('mt_rand'):
+                $data = $this->_generateBytesWithMtRand(16);
+                break;
+            default:
+                return 'unavailable';
+        }
+
+        return $this->_generateUUIDFromData($data);
+    }
+
+    /**
+     * Proxy around random_bytes
+     *
+     * @param $amt int
+     *
+     * @return string
+     * @codeCoverageIgnore
+     */
+    protected function _randomBytes($amt)
+    {
+        return random_bytes($amt);
+    }
+
+    /**
+     * Proxy around openssl_random_pseudo_bytes
+     *
+     * @param $amt int
+     *
+     * @return string
+     * @codeCoverageIgnore
+     */
+    protected function _opensslRandomPseudoBytes($amt)
+    {
+        return openssl_random_pseudo_bytes($amt);
+    }
+
+    /**
+     * Generate n Bytes with mt_rand
+     *
+     * @param $amt int
+     *
+     * @return string
+     */
+    protected function _generateBytesWithMtRand($amt)
+    {
+        $tmp = array();
+
+        for ($idx = 0; $idx < $amt; $idx++) {
+            $tmp[] = chr($this->_mtRand(0, 255));
+        }
+
+        return join('', $tmp);
+    }
+
+    /**
+     * Proxy around mt_rand
+     *
+     * @param $min int
+     * @param $max int
+     *
+     * @return int
+     * @codeCoverageIgnore
+     */
+    protected function _mtRand($min, $max)
+    {
+        return mt_rand($min, $max);
+    }
+
+    /**
+     * Proxy around is_callabe
+     *
+     * @param $callable
+     *
+     * @return bool
+     * @codeCoverageIgnore
+     */
+    protected function _isCallable($callable)
+    {
+        return is_callable($callable);
+    }
+
+    /**
+     * A UUIDv4 is formatted
+     * xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
+     * where x is 0-9, A-F and y is 8-9, A-B.
+     *
+     * @param $data     string  random bytes.
+     *
+     * @return string           valid, formatted UUIDv4
+     */
+    protected function _generateUUIDFromData($data)
+    {
+        $data = substr($data, 0, 16);
+
+        $data[6] = chr(ord($data[6]) & 0x0f | 0x40); // set the '4' in block 3
+        $data[8] = chr(ord($data[8]) & 0x3f | 0x80); // set bits for block 4
+
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
+    }
+}

--- a/tests/MonologCreator/FactoryTest.php
+++ b/tests/MonologCreator/FactoryTest.php
@@ -170,7 +170,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
                     },
                     "test" : {
                         "handler" : ["stream"],
-                        "processors": ["web"],
+                        "processors": ["web", "requestId"],
                         "level" : "INFO"
                     }
                 }
@@ -184,6 +184,10 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(
             '\Monolog\Processor\WebProcessor',
             $logger->getProcessors()[0]
+        );
+        $this->assertInstanceOf(
+            '\MonologCreator\Processor\RequestId',
+            $logger->getProcessors()[1]
         );
     }
 

--- a/tests/MonologCreator/Processor/RequestIdTest.php
+++ b/tests/MonologCreator/Processor/RequestIdTest.php
@@ -1,0 +1,237 @@
+<?php
+namespace MonologCreator\Processor;
+
+/**
+ * Class FormatterTest
+ *
+ * @package MonologCreator\Factory
+ */
+class RequestIdTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\MonologCreator\Processor\RequestId
+     */
+    private $subject = null;
+
+    public function setUp()
+    {
+        parent::setUp();
+    }
+
+    public function testConstructor()
+    {
+        $this->subject =
+            $this->getMockBuilder('MonologCreator\Processor\RequestId')
+                ->setMethods(
+                    array(
+                        '_generateUUID',
+                    )
+                )
+                ->getMock();
+        $this->subject->expects($this->once())
+            ->method('_generateUUID');
+        $this->subject->__construct();
+    }
+
+    public function testConstructorWithUUID()
+    {
+        $this->subject =
+            $this->getMockBuilder('MonologCreator\Processor\RequestId')
+                ->setMethods(
+                    array(
+                        '_generateUUID',
+                    )
+                )
+                ->getMock();
+        $this->subject->expects($this->never())
+            ->method('_generateUUID');
+        $this->subject->__construct('mock');
+    }
+
+    public function testInvoke()
+    {
+        $this->subject  = new RequestId('mock');
+        $record         = array('extra' => array());
+        $expectedRecord = array('extra' => array('request_id' => 'mock'));
+        $actual         = $this->subject->__invoke($record);
+        $this->assertEquals($expectedRecord, $actual);
+    }
+
+    public function testgenerateUUIDWithRandomBytes()
+    {
+        $this->subject =
+            $this->getMockBuilder('MonologCreator\Processor\RequestId')
+                ->setMethods(
+                    array(
+                        '_isCallable',
+                        '_randomBytes',
+                        '_generateUUIDFromData',
+                    )
+                )
+                ->disableOriginalConstructor()
+                ->getMock();
+
+        $this->subject->expects($this->at(0))
+            ->method('_isCallable')
+            ->with($this->equalTo('random_bytes'))
+            ->willReturn(true);
+
+        $this->subject->expects($this->at(1))
+            ->method('_randomBytes')
+            ->with($this->equalTo(16))
+            ->willReturn('abcdefgh12345678');
+
+        $this->subject->expects($this->once())
+            ->method('_generateUUIDFromData')
+            ->with($this->equalTo('abcdefgh12345678'));
+
+        $this->subject->__construct(null);
+    }
+
+    public function testgenerateUUIDWithOpenSSLRandomPseudoBytes()
+    {
+        $this->subject =
+            $this->getMockBuilder('MonologCreator\Processor\RequestId')
+                ->setMethods(
+                    array(
+                        '_isCallable',
+                        '_opensslRandomPseudoBytes',
+                        '_generateUUIDFromData',
+                    )
+                )
+                ->disableOriginalConstructor()
+                ->getMock();
+
+        $this->subject->expects($this->at(0))
+            ->method('_isCallable')
+            ->with($this->equalTo('random_bytes'))
+            ->willReturn(false);
+        $this->subject->expects($this->at(1))
+            ->method('_isCallable')
+            ->with($this->equalTo('openssl_random_pseudo_bytes'))
+            ->willReturn(true);
+
+        $this->subject->expects($this->at(2))
+            ->method('_opensslRandomPseudoBytes')
+            ->with($this->equalTo(16))
+            ->willReturn('abcdefgh12345678');
+
+        $this->subject->expects($this->once())
+            ->method('_generateUUIDFromData')
+            ->with($this->equalTo('abcdefgh12345678'));
+
+        $this->subject->__construct(null);
+    }
+
+    public function testgenerateUUIDWithMtRand()
+    {
+        $this->subject =
+            $this->getMockBuilder('MonologCreator\Processor\RequestId')
+                ->setMethods(
+                    array(
+                        '_isCallable',
+                        '_generateBytesWithMtRand',
+                        '_generateUUIDFromData',
+                    )
+                )
+                ->disableOriginalConstructor()
+                ->getMock();
+
+        $this->subject->expects($this->at(0))
+            ->method('_isCallable')
+            ->with($this->equalTo('random_bytes'))
+            ->willReturn(false);
+        $this->subject->expects($this->at(1))
+            ->method('_isCallable')
+            ->with($this->equalTo('openssl_random_pseudo_bytes'))
+            ->willReturn(false);
+        $this->subject->expects($this->at(2))
+            ->method('_isCallable')
+            ->with($this->equalTo('mt_rand'))
+            ->willReturn(true);
+
+        $this->subject->expects($this->at(3))
+            ->method('_generateBytesWithMtRand')
+            ->with($this->equalTo(16))
+            ->willReturn('abcdefgh12345678');
+
+        $this->subject->expects($this->once())
+            ->method('_generateUUIDFromData')
+            ->with($this->equalTo('abcdefgh12345678'));
+
+        $this->subject->__construct(null);
+    }
+
+    public function testgenerateUUIDWithoutRNG()
+    {
+        $this->subject =
+            $this->getMockBuilder('MonologCreator\Processor\RequestId')
+                ->setMethods(
+                    array(
+                        '_isCallable',
+                        '_generateBytesWithMtRand',
+                        '_generateUUIDFromData',
+                    )
+                )
+                ->disableOriginalConstructor()
+                ->getMock();
+
+        $this->subject->expects($this->at(0))
+            ->method('_isCallable')
+            ->with($this->equalTo('random_bytes'))
+            ->willReturn(false);
+        $this->subject->expects($this->at(1))
+            ->method('_isCallable')
+            ->with($this->equalTo('openssl_random_pseudo_bytes'))
+            ->willReturn(false);
+        $this->subject->expects($this->at(2))
+            ->method('_isCallable')
+            ->with($this->equalTo('mt_rand'))
+            ->willReturn(false);
+
+        $this->subject->expects($this->never())
+            ->method('_generateUUIDFromData');
+
+        $this->subject->__construct(null);
+    }
+
+    public function testgenerateBytesWithMtRand()
+    {
+        $this->subject =
+            $this->getMockBuilder('MonologCreator\Processor\RequestId')
+                ->setMethods(
+                    array(
+                        '_isCallable',
+                        '_generateUUIDFromData',
+                        '_mtRand',
+                    )
+                )
+                ->disableOriginalConstructor()
+                ->getMock();
+
+        $this->subject->expects($this->at(0))
+            ->method('_isCallable')
+            ->with($this->equalTo('random_bytes'))
+            ->willReturn(false);
+        $this->subject->expects($this->at(1))
+            ->method('_isCallable')
+            ->with($this->equalTo('openssl_random_pseudo_bytes'))
+            ->willReturn(false);
+        $this->subject->expects($this->at(2))
+            ->method('_isCallable')
+            ->with($this->equalTo('mt_rand'))
+            ->willReturn(true);
+
+        $this->subject->expects($this->exactly(16))
+            ->method('_mtRand')
+            ->with($this->equalTo(0), $this->equalTo(255))
+            ->willReturn(97);
+
+        $this->subject->expects($this->once())
+            ->method('_generateUUIDFromData')
+            ->with($this->equalTo('aaaaaaaaaaaaaaaa'));
+
+        $this->subject->__construct(null);
+    }
+}

--- a/tests/MonologCreator/Processor/RequestIdTest.php
+++ b/tests/MonologCreator/Processor/RequestIdTest.php
@@ -9,27 +9,25 @@ namespace MonologCreator\Processor;
 class RequestIdTest extends \PHPUnit_Framework_TestCase
 {
 
-    public function testConstructor()
-    {
-        $subject =
-            $this->getMockBuilder('MonologCreator\Processor\RequestId')
-                ->setMethods(
-                    array(
-                        '_generateUUID',
-                    )
-                )
-                ->getMock();
-        $subject->expects($this->once())
-            ->method('_generateUUID');
-        $subject->__construct();
-    }
-
     public function testInvoke()
     {
         $subject = new RequestId();
-        $record  = ['extra' => []];
+        $record  = array('extra' => array());
         $actual  = $subject->__invoke($record);
         $this->assertTrue(\array_key_exists('request_id', $actual['extra']));
+    }
+
+    public function testMultipleInvokesHaveSameID()
+    {
+        $subject = new RequestId();
+        $record  = array('extra' => array());
+        $actual1 = $subject->__invoke($record);
+        $actual2 = $subject->__invoke($record);
+        $this->assertTrue(\array_key_exists('request_id', $actual1['extra']));
+        $this->assertSame(
+            $actual1['extra']['request_id'],
+            $actual2['extra']['request_id']
+        );
     }
 
     /**
@@ -40,7 +38,7 @@ class RequestIdTest extends \PHPUnit_Framework_TestCase
     public function testGeneratedUUIDValid()
     {
         $subject = new RequestId();
-        $record  = ['extra' => []];
+        $record  = array('extra' => array());
         $actual  = $subject->__invoke($record);
         $UUID    = $actual['extra']['request_id'];
         $this->assertTrue(
@@ -74,7 +72,7 @@ class RequestIdTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo(16))
             ->willReturn('abcdefgh12345678');
 
-        $subject->__construct();
+        $subject->__invoke(array('extra' => array()));
     }
 
     public function testgenerateUUIDWithOpenSSLRandomPseudoBytes()
@@ -104,7 +102,7 @@ class RequestIdTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo(16))
             ->willReturn('abcdefgh12345678');
 
-        $subject->__construct(null);
+        $subject->__invoke(array('extra' => array()));
     }
 
     public function testgenerateUUIDWithMtRand()
@@ -138,7 +136,7 @@ class RequestIdTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo(16))
             ->willReturn('abcdefgh12345678');
 
-        $subject->__construct(null);
+        $subject->__invoke(array('extra' => array()));
     }
 
     public function testgenerateUUIDWithoutRNG()
@@ -167,7 +165,7 @@ class RequestIdTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('mt_rand'))
             ->willReturn(false);
 
-        $subject->__construct(null);
+        $subject->__invoke(array('extra' => array()));
     }
 
     public function testgenerateBytesWithMtRand()
@@ -201,6 +199,6 @@ class RequestIdTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo(0), $this->equalTo(255))
             ->willReturn(97);
 
-        $subject->__construct(null);
+        $subject->__invoke(array('extra' => array()));
     }
 }


### PR DESCRIPTION
# Changes:
- added a request-Id processor, that allows to inject a random ID for each request to make it easier to filter subsequent logs within the same request.
- added that processor to the readme.
- fixed a typo in the readme
